### PR TITLE
Index fix for message reading

### DIFF
--- a/src/lib_nfctype4pcd.cpp
+++ b/src/lib_nfctype4pcd.cpp
@@ -239,8 +239,8 @@ uint8_t PCDNFCT4_ReadNDEF( void )
 	}
 	if (size > 0)
 	{
-		errchk(PCDNFCT4_ReadBinary(0, size, buffer));
-		memcpy(&CardNDEFfile[0],&buffer[PCD_DATA_OFFSET+1],size);
+		errchk(PCDNFCT4_ReadBinary(i*limit, size, buffer));
+		memcpy(&CardNDEFfile[i*limit],&buffer[PCD_DATA_OFFSET+1],size);
 	}
 		
 	return PCDNFCT4_OK;


### PR DESCRIPTION
- Wrong index was used - causing long message to miss some bytes (data wasn't copied from and to the right address)
- After implementing correct index long messages are read correctly